### PR TITLE
Fix show of variant

### DIFF
--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -104,7 +104,7 @@ macro sum_type(T, blk::Expr, recur::Expr=:(recursive=false))
             $Base.indexed_iterate(x::$name, i::Int, state=1) = (Base.@_inline_meta; (getfield(x, i), i+1))
             $SumTypes.parent(::Type{<:$name}) = $T_name
             function $Base.show(io::IO, x::$name)
-                print(io, "$($name)(", join([x...], ", "), ")")
+                print(io, "$($name)(", join(map(repr, [x...]), ", "), ")")
             end 
         end
         push!(out.args, ex)


### PR DESCRIPTION
Before:
```
julia> Thing(0x00)
Option{UInt8}: Thing(0)
```
After:
```
julia> Thing(0x00)
Option{UInt8}: Thing(0x00)
```