### PR TITLE
More changes to show

### DIFF
--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -104,8 +104,13 @@ macro sum_type(T, blk::Expr, recur::Expr=:(recursive=false))
             $Base.indexed_iterate(x::$name, i::Int, state=1) = (Base.@_inline_meta; (getfield(x, i), i+1))
             $SumTypes.parent(::Type{<:$name}) = $T_name
             function $Base.show(io::IO, x::$name)
-                print(io, "$($name)(")
-                foreach(i -> show(io, i), x)
+                print(io, "$(Base.typename($name).name)")
+                isempty(x) && return nothing
+                print(io, '(')
+                for (i, elem) in enumerate(x)
+                    show(io, elem)
+                    i == fieldcount(typeof(x)) || print(io, ", ")
+                end
                 print(io, ')')
             end 
         end


### PR DESCRIPTION
Turns out show is a little harder than I expected...

Anyway, there is one more problem I don't know how to solve. I keep getting this warning 
```
WARNING: Method definition show(IO, Influenza.SubTypes.InfluenzaA) in module SubTypes at /Users/jakobnissen/code/SumTypes.jl/src/SumTypes.jl:106 overwritten in module MyNewModule 
```
, when I customize the `show` for any variants of a sum type. Worse still, it looks like the new show method doesn't even go into effect but is blocked by this warning!

It would be nice if that was fixed, but I don't know how.
