### PR TITLE
Fix method signatures [BREAKING - REVIEW]

### DIFF
--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -96,7 +96,7 @@ macro sum_type(T, blk::Expr, recur::Expr=:(recursive=false))
             :struct, false, nameparam_constrained, 
             Expr(:block, 
                  field_names_typed..., 
-                 :($nameparam($(field_names...)) where {$(T_params_constrained...)} =
+                 :($nameparam($(field_names_typed...)) where {$(T_params_constrained...)} =
                    $(Expr(:new, T, Expr(:new, nameparam, field_names...))))))
         ex = quote
             $struct_def

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,9 @@ let x = Left{Int, Int}(1)
     @test !(SumTypes.iscomplete(f, Either))
 end
 
-@test_throws TypeError Left{Int, String}("hi")
-@test_throws TypeError Right{Int, String}(1)
+@test_throws MethodError Left{Int, String}("hi")
+@test_throws MethodError Right{Int, String}(1)
+@test_throws MethodError Left{Int, Int}(0x01)
 
 @sum_type List{A, L} begin 
     Nil{A, L}()


### PR DESCRIPTION
Fix #6 

Note that this is breaking, since it means doing `Left{Int, Int}(0x01)` will fail. I think that is better than doing implicit conversions. Implicit conversions are shady in general, but for a sum type, it's even more dangerous, I think. 