### PR TITLE
Switch to Bit tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,14 +358,14 @@ end
 
 ```
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  84.288 μs … 293.964 μs  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     85.182 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   92.097 μs ±  18.142 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  76.941 μs … 285.838 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     83.523 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   89.009 μs ±  17.598 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-  █▁ ▁▆▄    ▃                                                  ▁
-  ██▇███▇▅▆▇█▇▇█▆█▆▇▅▇▅▆▆▇█▆▆▇▇▆▆▆█▅▅▅▅▆▅▅▅▅▅▄▅▃▃▄▅▅▆▆▅▅▃▅▅▂▅▅ █
-  84.3 μs       Histogram: log(frequency) by time       182 μs <
-  
+  ▆  ▂█▄▂  ▃▃▂                                                 ▁
+  ██▆████▆▅███▇██▇▆█▇▇▇▇█▇▇▆█▇▇▇█▇▆▆▆▆▇▅▇▇▆▆▆▆▆▆▆▅▆▆▅▅▆▅▅▅▅▆▅▅ █
+  76.9 μs       Histogram: log(frequency) by time       167 μs <
+
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 
@@ -434,7 +434,7 @@ BenchmarkTools.Trial: 10000 samples with 1 evaluation.
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 
-Unityper.jl and SumTypes.jl are about equal in this benchmark. SumTypes.jl has some advantages relative to Unityper.jl too, such as:
+Unityper.jl SumTypes.jl is slightly slower in this benckmark, though there are others where it is faster. SumTypes.jl has some advantages relative to Unityper.jl too, such as:
 - SumTypes.jl allows [parametric types](https://docs.julialang.org/en/v1/manual/types/#Parametric-Types) for much greater container flexibility (Unityper does some memory layout optimizations that won't work with parametric types). 
 - SumTypes.jl does not require default values for every field of the struct
 - SumTypes.jl's `@cases` macro is more powerful and flexible than Unityper's `@compactified`.

--- a/README.md
+++ b/README.md
@@ -358,14 +358,14 @@ end
 
 ```
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  74.210 μs … 231.032 μs  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     75.119 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   79.962 μs ±  13.458 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  84.288 μs … 293.964 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     85.182 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   92.097 μs ±  18.142 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-  █▃  ▄▂▄  ▄▃   ▂▁                                             ▁
-  ███▆████▅███▇▇████▆█▅▇▅▇▇▆▇▆▅▅▅▆▅▅▅▅▅▅▅▆▅▅▅▆▅▅▅▅▅▁▅▅▅▅▅▄▄▅▅▅ █
-  74.2 μs       Histogram: log(frequency) by time       152 μs <
-
+  █▁ ▁▆▄    ▃                                                  ▁
+  ██▇███▇▅▆▇█▇▇█▆█▆▇▅▇▅▆▆▇█▆▆▇▇▆▆▆█▅▅▅▅▆▅▅▅▅▅▄▅▃▃▄▅▅▆▆▅▅▃▅▅▂▅▅ █
+  84.3 μs       Histogram: log(frequency) by time       182 μs <
+  
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -12,6 +12,10 @@ function unwrap end
 function tags end
 function deparameterize end
 is_sumtype(::Type{T}) where {T}   = false
+function flagtype end
+function flag_to_symbol end
+function symbol_to_flag end
+function tags_flags_nt end
 
 
 struct Unsafe end
@@ -25,15 +29,19 @@ maybe_type(::Type{x}) where {x} = x
 maybe_type(::Singleton{x}) where {x} = Singleton{x}
 
 const tag = Symbol("#tag#")
-get_tag(x) =getfield(x, tag) 
+get_tag(x) =getfield(x, tag)
+get_tag_sym(x::T) where {T} = tags_flags_nt(T)[get_tag(x)]
+# get_tag(x::T) where {T} = getfield(x, tag)
+
 
 show_sumtype(io::IO, m::MIME, x) = show_sumtype(io, x)
-function show_sumtype(io::IO, x)
+function show_sumtype(io::IO, x::T) where {T}
     tag = get_tag(x)
-    if getfield(x, tag) isa Singleton
-        print(io, String(tag), "::", typeof(x))
+    sym = flag_to_symbol(T, tag)
+    if getfield(x, sym) isa Singleton
+        print(io, String(sym), "::", typeof(x))
     else
-        print(io, String(tag), '(', join((repr(data) for data ∈ getfield(x, tag)), ", "), ")::", typeof(x))
+        print(io, String(sym), '(', join((repr(data) for data ∈ getfield(x, sym)), ", "), ")::", typeof(x))
     end
 end
 

--- a/src/cases.jl
+++ b/src/cases.jl
@@ -19,10 +19,6 @@
     :($ret)
 end
 
-@inline @generated function symbol_to_flag(::Type{T}, ::Val{s}) where {T, s}
-    symbol_to_flag(T, s)
-end
-
 macro cases(to_match, block)
     @assert block.head == :block
     lnns = filter(block.args) do arg

--- a/src/cases.jl
+++ b/src/cases.jl
@@ -86,7 +86,7 @@ macro cases(to_match, block)
         let $data = $to_match
             $Typ = $typeof($data)
             $check_sum_type($Typ)
-            $nt = $tags_flags_nt($Typ)
+            # $nt = $tags_flags_nt($Typ)
             $assert_exhaustive(Val{$tags($Typ)}, Val{$(Expr(:tuple, QuoteNode.(deparameterize.(variants))...))})
             $ex
         end

--- a/src/cases.jl
+++ b/src/cases.jl
@@ -5,17 +5,22 @@
 @noinline matching_error() = throw(error("Something went wrong during matching"))
 
 @generated function assert_exhaustive(::Type{Val{tags}}, ::Type{Val{variants}}) where {tags, variants}
+    ret = nothing
     for tag ∈ tags
         if tag ∉ variants 
-            throw(error("Inexhaustive @cases specification. Got cases $(variants), expected $(tags)"))
+            ret = error("Inexhaustive @cases specification. Got cases $(variants), expected $(tags)")
         end
     end
     for variant ∈ variants
         if variant ∉ tags
-            throw(error("Unexpected variant $variant provided. Valid variants are: $(tags)"))
+            ret = error("Unexpected variant $variant provided. Valid variants are: $(tags)")
         end
     end
-    nothing
+    :($ret)
+end
+
+@inline @generated function symbol_to_flag(::Type{T}, ::Val{s}) where {T, s}
+    symbol_to_flag(T, s)
 end
 
 macro cases(to_match, block)
@@ -52,9 +57,10 @@ macro cases(to_match, block)
     @gensym con
     @gensym con_Union
     @gensym Typ
+    @gensym nt
     variants = map(x -> x.variant, stmts)
     
-    ex = :(if $get_tag($data) === $(QuoteNode(stmts[1].variant));
+    ex = :(if $get_tag($data) === $symbol_to_flag($Typ, $(QuoteNode(stmts[1].variant)));
                $(stmts[1].iscall ? :(($(stmts[1].fieldnames...),) =
                    $getfield($data, $(QuoteNode(stmts[1].variant))) :: $constructor($Typ, $Val{$(QuoteNode(stmts[1].variant))}  )) : nothing);
                $(stmts[1].rhs)
@@ -63,9 +69,9 @@ macro cases(to_match, block)
     pushfirst!(ex.args[2].args, lnns[1])
     to_push = ex.args
     for i ∈ 2:length(stmts)
-        _if = :(if $get_tag($data) === $(QuoteNode(stmts[i].variant));
+        _if = :(if $get_tag($data) === $symbol_to_flag($Typ, $(QuoteNode(stmts[i].variant)));
                     $(stmts[i].iscall ? :(($(stmts[i].fieldnames...),) =
-                        $getfield($data, $(QuoteNode(stmts[i].variant))):: $constructor($Typ, $Val{$(QuoteNode(stmts[i].variant))}   )) : nothing);
+                        $getfield($data, $(QuoteNode(stmts[i].variant))) :: $constructor($Typ, $Val{$(QuoteNode(stmts[i].variant))}   )) : nothing);
                     $(stmts[i].rhs)
                 end)
         _if.head = :elseif
@@ -80,6 +86,7 @@ macro cases(to_match, block)
         let $data = $to_match
             $Typ = $typeof($data)
             $check_sum_type($Typ)
+            $nt = $tags_flags_nt($Typ)
             $assert_exhaustive(Val{$tags($Typ)}, Val{$(Expr(:tuple, QuoteNode.(deparameterize.(variants))...))})
             $ex
         end

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -239,11 +239,11 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_n
         $SumTypes.flagtype(::Type{<:$T_name}) = $flagtype
         
         $SumTypes.symbol_to_flag(::Type{<:$T_name}, sym::Symbol) =
-            $(foldr(enumerate(con_names), init=:(error("Invalid tag symbol $sym"))) do (i, _sym), old
+            $(foldr(collect(enumerate(con_names)), init=:(error("Invalid tag symbol $sym"))) do (i, _sym), old
                   Expr(:if, :(sym == $(QuoteNode(_sym))), flagtype(i), old)
               end)
         $SumTypes.flag_to_symbol(::Type{<:$T_name}, flag::$flagtype) =
-            $(foldr(enumerate(con_names), init=:(error("Invalid tag symbol $sym"))) do (i, sym), old
+            $(foldr(collect(enumerate(con_names)), init=:(error("Invalid tag symbol $sym"))) do (i, sym), old
                   Expr(:if, :(flag == $i), QuoteNode(sym), old)
               end)
         $SumTypes.tags_flags_nt(::Type{<:$T_name}) = $(Expr(:tuple, Expr(:parameters, (Expr(:kw, name, flagtype(i)) for (i, name) ∈ enumerate(con_names))...)))

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -1,3 +1,4 @@
+
 macro sum_type(T, blk, _hide_variants=:(hide_variants = false))
     if _hide_variants isa Expr && _hide_variants.head == :(=) && _hide_variants.args[1] == :hide_variants
         hide_variants = _hide_variants.args[2]
@@ -23,147 +24,12 @@ macro sum_type(T, blk, _hide_variants=:(hide_variants = false))
     out, converts, singletons = generate_constructor_exprs(T_name, T_params, T_params_constrained, T_nameparam, constructors)
     ex = generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_nameparam, constructors, singletons)
     push!(out.args, ex)
+    push!(out.args, singletons)
     push!(out.args, converts...) # Conversion statements requre T to be defined
     esc(out)
 end
 
-function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_nameparam, constructors, singletons)
-        
-    con_nameparams  = (x -> x.nameparam ).(constructors)
-    con_gnameparams = (x -> x.gnameparam).(constructors)
-    con_names       = (x -> x.name      ).(constructors)
-    con_gnames      = (x -> x.gname     ).(constructors)
-    
-    data_fields = map(constructors) do nt
-        (name, params, nameparam, field_names, types, params_uninit, params_constrained, singleton, gname, gnameparam) = nt
-        if singleton
-            :($name :: $gnameparam)
-            #nothing
-        else
-            :($name :: Union{$gnameparam, Nothing})
-        end
-    end
-    sum_struct_def = Expr(:struct, false, T, Expr(:block, data_fields..., :($tag::Symbol), :(1 + 1)))
-
-    if_nest_unwrap = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old), constructors, init=:(error("invalid tag"))) do nt
-        (name, _, _, _, _, _, _, _, _, gnameparam) = nt
-        :(tag === $(QuoteNode(name))), :($getfield(x, $(QuoteNode(name))) :: $gnameparam) 
-    end
-    ex = quote
-        $sum_struct_def
-        $singletons
-        $SumTypes.constructors(::Type{$T_name}) =
-            $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.singleton ? nt.gnameparam : nt.gname for nt ∈ constructors)...)))
-        $SumTypes.constructors(::Type{$T_nameparam}) where {$(T_params...)} =
-            $NamedTuple{$tags($T_name)}($(Expr(:tuple,
-                                               (nt.gnameparam for nt ∈ constructors)...)))
-        $SumTypes.constructors_Union(::Type{$T_nameparam}) where {$(T_params...)}= $Union{$((nt.nameparam for nt ∈ constructors)...)}
-        $SumTypes.constructors_Union(::Type{$T_name}) = $Union{$((nt.singleton ? nt.nameparam : nt.name for nt ∈ constructors)...)}
-        $SumTypes.is_sumtype(::Type{<:$T_name}) = true
-        $SumTypes.unwrap(x::$T_nameparam) where {$(T_params...)}= let tag = getfield(x, $(QuoteNode(tag)))
-            $if_nest_unwrap
-        end
-        #$Base.adjoint(::Type{T}) where {T <: $T_name} = $SumTypes.constructors(T)
-        $Base.adjoint(::Type{$T_name}) =
-            $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.gname  for nt ∈ constructors)...)))
-        
-        $Base.adjoint(::Type{$T_nameparam}) where {$(T_params...)} =
-            $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.singleton ? :($T_nameparam($(nt.gname))) : nt.gnameparam  for nt ∈ constructors)...)))
-        $Base.show(io::IO, x::$T_name) = $show_sumtype(io, x)
-        $Base.show(io::IO, m::MIME"text/plain", x::$T_name) = $show_sumtype(io, m, x)
-        
-        #$SumTypes.deparameterize(::Type{<:$T_name}) = $T_name
-        $SumTypes.tags(::Type{<:$T_name}) = $(Expr(:tuple, map(x -> QuoteNode(x.name), constructors)...))
-        Base.:(==)(x::$T_name, y::$T_name) = $unwrap(x) == $unwrap(y)
-    end
-    foreach(constructors) do (name, params, nameparam, field_names, types, params_uninit, params_constrained, singleton, gname, gnameparam)
-        cons = quote
-            $SumTypes.constructor(::Type{$T_name}, ::Type{Val{$(QuoteNode(name))}}) = $(singleton ? gnameparam : gname)
-            $SumTypes.constructor(::Type{$T_nameparam}, ::Type{Val{$(QuoteNode(name))}}) where {$(T_params...)} = $gnameparam
-        end
-        push!(ex.args, cons)
-    end
-    ex
-end
-
-function generate_constructor_exprs(T_name, T_params, T_params_constrained, T_nameparam, constructors)
-    out = Expr(:toplevel)
-    converts = []
-    singletons = Expr(:block)
-    foreach(constructors) do (name, params, nameparam, field_names, types, params_uninit, params_constrained, singleton, gname, gnameparam)
-        nameparam_constrained = isempty(params) ? name : :($name{$(params_constrained...)})
-        gnameparam_constrained = isempty(params) ? gname : :($gname{$(params_constrained...)})
-        T_uninit = isempty(T_params) ? T_name : :($T_name{$(params_uninit...)})
-        T_init = isempty(T_params) ? T_name : :($T_name{$(T_params...)})
-        if singleton
-            T_con_fields = map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
-                default = singleton ? :($_gnameparam()) : nothing
-                _name == name ? Singleton{gname}() : default
-            end
-            ex = quote
-                const $gname = $(Expr(:new, T_uninit, T_con_fields..., QuoteNode(name)))
-                # $SumTypes.parent(::Type{$Singleton{$(QuoteNode(name))}}) = $T_name
-            end
-            push!(singletons.args, ex)
-        else
-            field_names_typed = map(field_names, types) do name, type
-                :($name :: $type)
-            end
-            T_con_fields = map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
-                default = singleton ? :($_gnameparam()) : nothing
-                _name == name ? Expr(:new, gnameparam, field_names...) : default
-            end
-            T_con = :($gnameparam($(field_names_typed...)) where {$(params_constrained...)} =
-                $(Expr(:new, T_uninit, T_con_fields..., QuoteNode(name))))
-            
-            T_con_fields2 = map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
-                default = singleton ? :($_gnameparam()) : nothing
-                s = Expr(:new, gnameparam, [:($convert($type, $field_name)) for (type, field_name) ∈ zip(types, field_names)]...)
-                _name == name ? s : default
-            end
-            T_con2 = :($gnameparam($(field_names...)) where {$(params_constrained...)} =
-                $(Expr(:new, T_uninit, T_con_fields2..., QuoteNode(name))))
-            
-            unsafe_con = :($gnameparam(::$Unsafe, $(field_names_typed...)) where {$(params_constrained...)} = new{$(params...)}($(field_names...)))
-            struct_def = Expr(:struct, false, gnameparam_constrained, 
-                              Expr(:block, field_names_typed..., T_con, T_con2, unsafe_con))
-            maybe_no_param = if !isempty(params)
-                :($gname($(field_names_typed...)) where {$(params...)} = $gnameparam($(field_names...)))
-            end
-            ex = quote
-                $struct_def
-                $maybe_no_param
-                @inline $Base.iterate(x::$gname, s = 1) = s ≤ fieldcount($gname) ? (getfield(x, s), s + 1) : nothing
-                $Base.indexed_iterate(x::$gname, i::Int, state=1) = (Base.@_inline_meta; (getfield(x, i), i+1))
-                $SumTypes.parent(::Type{<:$gname}) = $T_name
-                function Base.:(==)(x::$gname, y::$gname)
-                    $(foldl((old, field) -> :($old && $isequal($getfield(x, $field), $getfield(y, $field))), QuoteNode.(field_names), init=true))
-                end
-            end
-            push!(out.args, ex)
-        end
-        if_nest = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old), constructors, init=:(error("invalid tag"))) do (name,
-                                                                                                                              _,
-                                                                                                                              nameparam,
-                                                                                                                              _, _, _, _,
-                                                                                                                              _,
-                                                                                                                              gname,
-                                                                                                                              gnameparam)
-            data =  map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
-                default = singleton ? :($_gnameparam()) : nothing
-                _name == name ? :($getfield(x, $(QuoteNode(name))) :: $gnameparam) : default
-            end
-            :(tag === $(QuoteNode(name))), Expr(:new, T_init, data..., :tag)
-        end
-        if true#!isempty(T_params)
-            push!(converts,
-                  :($Base.convert(::Type{$T_init}, x::$T_uninit) where {$(T_params...)} = $(Expr(:block,
-                                                                                                 :(tag = getfield(x, $(QuoteNode(tag)) )), if_nest ))))
-            push!(converts, :($T_init(x::$T_uninit) where {$(T_params...)} = $convert($T_init, x)))
-        end
-    end
-    out, converts, singletons
-end
+#------------------------------------------------------
 
 function generate_constructor_data(T_name, T_params, T_params_constrained, T_nameparam, hide_variants, blk::Expr)
     constructors = []
@@ -253,3 +119,164 @@ function generate_constructor_data(T_name, T_params, T_params_constrained, T_nam
     constructors
 end
 
+#------------------------------------------------------
+
+function generate_constructor_exprs(T_name, T_params, T_params_constrained, T_nameparam, constructors)
+    out = Expr(:toplevel)
+    converts = []
+    singletons = Expr(:block)
+    foreach(constructors) do (name, params, nameparam, field_names, types, params_uninit, params_constrained, singleton, gname, gnameparam)
+        nameparam_constrained = isempty(params) ? name : :($name{$(params_constrained...)})
+        gnameparam_constrained = isempty(params) ? gname : :($gname{$(params_constrained...)})
+        T_uninit = isempty(T_params) ? T_name : :($T_name{$(params_uninit...)})
+        T_init = isempty(T_params) ? T_name : :($T_name{$(T_params...)})
+        if singleton
+            T_con_fields = map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
+                default = singleton ? :($_gnameparam()) : nothing
+                _name == name ? Singleton{gname}() : default
+            end
+            ex = quote
+                const $gname = $(Expr(:new, T_uninit, T_con_fields..., Expr(:call, symbol_to_flag, T_name, QuoteNode(name)) ))
+                # $SumTypes.parent(::Type{$Singleton{$(QuoteNode(name))}}) = $T_name
+            end
+            push!(singletons.args, ex)
+        else
+            field_names_typed = map(field_names, types) do name, type
+                :($name :: $type)
+            end
+            T_con_fields = map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
+                default = singleton ? :($_gnameparam()) : nothing
+                _name == name ? Expr(:new, gnameparam, field_names...) : default
+            end
+            T_con = :($gnameparam($(field_names_typed...)) where {$(params_constrained...)} =
+                $(Expr(:new, T_uninit, T_con_fields..., Expr(:call, symbol_to_flag, T_name, QuoteNode(name)) ) ))
+            
+            T_con_fields2 = map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
+                default = singleton ? :($_gnameparam()) : nothing
+                s = Expr(:new, gnameparam, [:($convert($type, $field_name)) for (type, field_name) ∈ zip(types, field_names)]...)
+                _name == name ? s : default
+            end
+            T_con2 = :($gnameparam($(field_names...)) where {$(params_constrained...)} =
+                $(Expr(:new, T_uninit, T_con_fields2..., Expr(:call, symbol_to_flag, T_name, QuoteNode(name)) )))
+            
+            unsafe_con = :($gnameparam(::$Unsafe, $(field_names_typed...)) where {$(params_constrained...)} = new{$(params...)}($(field_names...)))
+            struct_def = Expr(:struct, false, gnameparam_constrained, 
+                              Expr(:block, field_names_typed..., T_con, T_con2, unsafe_con))
+            maybe_no_param = if !isempty(params)
+                :($gname($(field_names_typed...)) where {$(params...)} = $gnameparam($(field_names...)))
+            end
+            ex = quote
+                $struct_def
+                $maybe_no_param
+                @inline $Base.iterate(x::$gname, s = 1) = s ≤ fieldcount($gname) ? (getfield(x, s), s + 1) : nothing
+                $Base.indexed_iterate(x::$gname, i::Int, state=1) = (Base.@_inline_meta; (getfield(x, i), i+1))
+                $SumTypes.parent(::Type{<:$gname}) = $T_name
+                function Base.:(==)(x::$gname, y::$gname)
+                    $(foldl((old, field) -> :($old && $isequal($getfield(x, $field), $getfield(y, $field))), QuoteNode.(field_names), init=true))
+                end
+            end
+            push!(out.args, ex)
+        end
+        if_nest = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old), enumerate(constructors), init=:(error("invalid tag"))) do (i , (name,
+                                                                                                                                              _,
+                                                                                                                                              nameparam,
+                                                                                                                                              _, _, _, _,
+                                                                                                                                              _,
+                                                                                                                                              gname,
+                                                                                                                                              gnameparam))
+            data =  map(constructors) do (_name, _, _nameparam, _, _, _, _, singleton, _gname, _gnameparam)
+                default = singleton ? :($_gnameparam()) : nothing
+                _name == name ? :($getfield(x, $(QuoteNode(name))) :: $gnameparam) : default
+            end
+            :(tag == $i), Expr(:new, T_init, data..., :tag)
+        end
+        if true#!isempty(T_params)
+            push!(converts,
+                  :($Base.convert(::Type{$T_init}, x::$T_uninit) where {$(T_params...)} = $(Expr(:block,
+                                                                                                 :(tag = getfield(x, $(QuoteNode(tag)) )),
+                                                                                                 if_nest ))))
+            push!(converts, :($T_init(x::$T_uninit) where {$(T_params...)} = $convert($T_init, x)))
+        end
+    end
+    out, converts, singletons
+end
+
+
+
+#------------------------------------------------------
+
+function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_nameparam, constructors, singletons)
+        
+    con_nameparams  = (x -> x.nameparam ).(constructors)
+    con_gnameparams = (x -> x.gnameparam).(constructors)
+    con_names       = (x -> x.name      ).(constructors)
+    con_gnames      = (x -> x.gname     ).(constructors)
+
+    flagtype = length(constructors) <= typemax(UInt8) ? UInt8 : length(constructors) < typemax(UInt16) ? UInt16 :
+        error("Too many variants in SumType, got $(length(constructors)). The current maximum number is $(typemax(UInt16) |> Int)")
+    
+    data_fields = map(constructors) do nt
+        (name, params, nameparam, field_names, types, params_uninit, params_constrained, singleton, gname, gnameparam) = nt
+        if singleton
+            :($name :: $gnameparam)
+            #nothing
+        else
+            :($name :: Union{$gnameparam, Nothing})
+        end
+    end
+    
+    sum_struct_def = Expr(:struct, false, T, Expr(:block, data_fields..., :($tag :: $flagtype), :(1 + 1)))
+
+    if_nest_unwrap = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old), enumerate(constructors), init=:(error("invalid tag"))) do (i, nt)
+        (name, _, _, _, _, _, _, _, _, gnameparam) = nt
+        :(tag == $i), :($getfield(x, $(QuoteNode(name))) :: $gnameparam) 
+    end
+   
+    ex = quote
+        $sum_struct_def
+ 
+        $SumTypes.flagtype(::Type{<:$T_name}) = $flagtype
+        
+        $SumTypes.symbol_to_flag(::Type{<:$T_name}, sym::Symbol) =
+            $(foldr(enumerate(con_names), init=:(error("Invalid tag symbol $sym"))) do (i, _sym), old
+                  Expr(:if, :(sym == $(QuoteNode(_sym))), flagtype(i), old)
+              end)
+        $SumTypes.flag_to_symbol(::Type{<:$T_name}, flag::$flagtype) =
+            $(foldr(enumerate(con_names), init=:(error("Invalid tag symbol $sym"))) do (i, sym), old
+                  Expr(:if, :(flag == $i), QuoteNode(sym), old)
+              end)
+        $SumTypes.tags_flags_nt(::Type{<:$T_name}) = $(Expr(:tuple, Expr(:parameters, (Expr(:kw, name, flagtype(i)) for (i, name) ∈ enumerate(con_names))...)))
+        $SumTypes.tags(::Type{<:$T_name}) = $(Expr(:tuple, map(x -> QuoteNode(x.name), constructors)...))
+        
+        $SumTypes.constructors(::Type{$T_name}) =
+            $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.singleton ? nt.gnameparam : nt.gname for nt ∈ constructors)...)))
+        $SumTypes.constructors(::Type{$T_nameparam}) where {$(T_params...)} =
+            $NamedTuple{$tags($T_name)}($(Expr(:tuple,
+                                               (nt.gnameparam for nt ∈ constructors)...)))
+        $SumTypes.constructors_Union(::Type{$T_nameparam}) where {$(T_params...)}= $Union{$((nt.nameparam for nt ∈ constructors)...)}
+        $SumTypes.constructors_Union(::Type{$T_name}) = $Union{$((nt.singleton ? nt.nameparam : nt.name for nt ∈ constructors)...)}
+        $SumTypes.is_sumtype(::Type{<:$T_name}) = true
+        $SumTypes.unwrap(x::$T_nameparam) where {$(T_params...)}= let tag = $get_tag(x)
+            $if_nest_unwrap
+        end
+        #$Base.adjoint(::Type{T}) where {T <: $T_name} = $SumTypes.constructors(T)
+    $Base.adjoint(::Type{$T_name}) =
+        $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.gname  for nt ∈ constructors)...)))
+    
+    $Base.adjoint(::Type{$T_nameparam}) where {$(T_params...)} =
+            $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.singleton ? :($T_nameparam($(nt.gname))) : nt.gnameparam  for nt ∈ constructors)...)))
+        $Base.show(io::IO, x::$T_name) = $show_sumtype(io, x)
+        $Base.show(io::IO, m::MIME"text/plain", x::$T_name) = $show_sumtype(io, m, x)
+        
+        #$SumTypes.deparameterize(::Type{<:$T_name}) = $T_name
+        Base.:(==)(x::$T_name, y::$T_name) = $unwrap(x) == $unwrap(y)
+    end
+    foreach(constructors) do (name, params, nameparam, field_names, types, params_uninit, params_constrained, singleton, gname, gnameparam)
+        cons = quote
+            $SumTypes.constructor(::Type{$T_name}, ::Type{Val{$(QuoteNode(name))}}) = $(singleton ? gnameparam : gname)
+            $SumTypes.constructor(::Type{$T_nameparam}, ::Type{Val{$(QuoteNode(name))}}) where {$(T_params...)} = $gnameparam
+        end
+        push!(ex.args, cons)
+    end
+    ex
+end

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -227,8 +227,8 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_n
     end
     
     sum_struct_def = Expr(:struct, false, T, Expr(:block, data_fields..., :($tag :: $flagtype), :(1 + 1)))
-    
-    if_nest_unwrap = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old), enumerate(constructors), init=:(error("invalid tag"))) do (i, nt)
+    enumerate_constructors = collect(enumerate(constructors))
+    if_nest_unwrap = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old),  enumerate_constructors, init=:(error("invalid tag"))) do (i, nt)
         (name, _, _, _, _, _, _, _, _, gnameparam) = nt
         :(tag == $i), :($getfield(x, $(QuoteNode(name))) :: $gnameparam) 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ function Base.show(io::IO, l::List)
 end
 #-------------------
 @testset "Basics  " begin
+    @test SumTypes.is_sumtype(Int) == false
     @test Bar(1) isa Foo
     @test_throws MethodError Foo(1)
 
@@ -62,6 +63,14 @@ end
             end
         end
     end
+    
+    @test_throws ErrorException either_test_overcomplete(Left(1))
+
+    @test_throws ErrorException macroexpand(@__MODULE__(), :(@cases x begin
+        Left{Int}(x) => x
+        Right(x) => x
+    end))
+    
     
     @test_throws ErrorException either_test_overcomplete(Left(1))
 
@@ -130,11 +139,11 @@ end hide_variants = true
     @test Hider'.B != B
 
     @test 1 == @cases Hider'.A begin
-        A => 1
+        A() => 1
         B(a) => a
     end
     @test 2 == @cases Hider'.B(2) begin
-        A => 1
+        A() => 1
         B(a) => a
     end
 
@@ -153,6 +162,8 @@ end hide_variants = true
     end
 end
 
+
+
 @sum_type Either2{A, B} begin
     Left{A}(::A)
     Right{B}(::B)
@@ -168,6 +179,12 @@ SumTypes.show_sumtype(io::IO, ::MIME"text/plain", x::Either2) = @cases x begin
     Right(a) => print(io, "The Rightestmost Value: $a")
 end
 
+@sum_type Fruit begin
+    apple
+    banana
+    orange
+end
+
 @testset "printing  " begin
     @test repr(Left(1)) ∈  ("Left(1)::Either{Int64, Uninit}", "Left(1)::Either{Int64,Uninit}") 
     @test repr("text/plain", Right(3)) ∈ ("Right(3)::Either{Uninit, Int64}", "Right(3)::Either{Uninit,Int64}")
@@ -176,5 +193,6 @@ end
         @test repr("text/plain", Left(1)) == "The Leftestmost Value: 1"
         @test repr(Right(3)) == "R(3)"
     end
+    @test repr(apple) == "apple::Fruit"
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ end
     
     @test_throws ErrorException either_test_overcomplete(Left(1))
 
-    @test_throws ErrorException macroexpand(@__MODULE__(), :(@cases x begin
+    @test_throws Exception macroexpand(@__MODULE__(), :(@cases x begin
         Left{Int}(x) => x
         Right(x) => x
     end))


### PR DESCRIPTION
Switch over to storing bits for the tag instead of a `Symbol` for distinguishing different variants. The the tag is either a `UInt8` or `UInt16` depending on if there are more or less than `255` variants. I currently just throw an error if the user supplies so many variants that a `UInt16` isn't big enough, as I suspect that'd be bad anyways.

Can be relaxed if needed though. Should be non-breaking for anyone not messing around with the internals. 