### PR TITLE
allow recursive sum types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/README.md
+++ b/README.md
@@ -358,13 +358,13 @@ end
 
 ```
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  76.941 μs … 285.838 μs  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     83.523 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   89.009 μs ±  17.598 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  61.309 μs …  83.300 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     62.350 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   62.376 μs ± 528.152 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-  ▆  ▂█▄▂  ▃▃▂                                                 ▁
-  ██▆████▆▅███▇██▇▆█▇▇▇▇█▇▇▆█▇▇▇█▇▆▆▆▆▇▅▇▇▆▆▆▆▆▆▆▅▆▆▅▅▆▅▅▅▅▆▅▅ █
-  76.9 μs       Histogram: log(frequency) by time       167 μs <
+                  ▃█▂       ▁▄▃▂                                
+  ▂▁▁▁▁▁▁▁▁▂▁▂▃▅▅▇███▆▄▃▃▄▄▇████▅▄▃▂▂▂▁▂▂▂▁▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
+  61.3 μs         Histogram: frequency by time           64 μs <
 
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
@@ -434,7 +434,8 @@ BenchmarkTools.Trial: 10000 samples with 1 evaluation.
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 
-Unityper.jl SumTypes.jl is slightly slower in this benckmark, though there are others where it is faster. SumTypes.jl has some advantages relative to Unityper.jl too, such as:
+SumTypes.jl is able to slightly beat Unityper.jl in this benckmark, though there are cases where the roles are reversed. 
+SumTypes.jl has some other advantages relative to Unityper.jl too, such as:
 - SumTypes.jl allows [parametric types](https://docs.julialang.org/en/v1/manual/types/#Parametric-Types) for much greater container flexibility (Unityper does some memory layout optimizations that won't work with parametric types). 
 - SumTypes.jl does not require default values for every field of the struct
 - SumTypes.jl's `@cases` macro is more powerful and flexible than Unityper's `@compactified`.

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -23,17 +23,12 @@ const unsafe = Unsafe()
 
 struct Uninit end
 
-# struct Singleton{name} end
-# Singleton{name}(::Unsafe) where {name} = Singleton{name}()
-# Base.iterate(x::Singleton, s = 1) = nothing
-# maybe_type(::Type{x}) where {x} = x
-# maybe_type(::Singleton{x}) where {x} = Singleton{x}
 
 struct Variant{fieldnames, Tup <: Tuple}
     data::Tup
     Variant{fieldnames, Tup}(::Unsafe) where {fieldnames, Tup} = new{fieldnames, Tup}()
-    Variant(::Unsafe, nt::NamedTuple{names, Tup}) where {names, Tup} = new{fieldnames, Tup}(Tuple(nt))
-    Variant{fieldnames}(t::Tup) where {fieldnames, Tup <: Tuple} = new{fieldnames, Tup}(t)
+    # Variant(::Unsafe, nt::NamedTuple{names, Tup}) where {names, Tup} = new{fieldnames, Tup}(Tuple(nt))
+    # Variant{fieldnames}(t::Tup) where {fieldnames, Tup <: Tuple} = new{fieldnames, Tup}(t)
     Variant{fieldnames, Tup}(t::Tuple) where {fieldnames, Tup <: Tuple} = new{fieldnames, Tup}(t)
 end
 Base.:(==)(v1::Variant, v2::Variant) = v1.data == v2.data
@@ -41,15 +36,9 @@ Base.:(==)(v1::Variant, v2::Variant) = v1.data == v2.data
 Base.iterate(x::Variant, s = 1) = iterate(x.data, s)
 Base.indexed_iterate(x::Variant, i::Int, state=1) = (Base.@_inline_meta; (getfield(x.data, i), i+1))
 
-maybe_type(::Type{x}) where {x} = x
-maybe_type(::Variant{fieldnames, Tup}) where {fieldnames, Tup} = Variant{fieldnames, Tup}
-#maybe_type(::Singleton{x}) where {x} = Singleton{x}
-
 const tag = Symbol("#tag#")
-get_tag(x) =getfield(x, tag)
-get_tag_sym(x::T) where {T} = tags_flags_nt(T)[get_tag(x)]
-# get_tag(x::T) where {T} = getfield(x, tag)
-
+get_tag(x) = getfield(x, tag)
+get_tag_sym(x::T) where {T} = keys(tags_flags_nt(T))[Int(get_tag(x))]
 
 show_sumtype(io::IO, m::MIME, x) = show_sumtype(io, x)
 function show_sumtype(io::IO, x::T) where {T}

--- a/src/cases.jl
+++ b/src/cases.jl
@@ -58,7 +58,7 @@ macro cases(to_match, block)
     
     ex = :(if $get_tag($data) === $symbol_to_flag($Typ, $(QuoteNode(stmts[1].variant)));
                $(stmts[1].iscall ? :(($(stmts[1].fieldnames...),) =
-                   $getfield($data, $(QuoteNode(stmts[1].variant))) :: $constructor($Typ, $Val{$(QuoteNode(stmts[1].variant))}  )) : nothing);
+                   $getfield($data, $(QuoteNode(stmts[1].variant))) :: $constructor($Typ, $Val{$(QuoteNode(stmts[1].variant))}  )  ) : nothing);
                $(stmts[1].rhs)
            end)
     Base.remove_linenums!(ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,9 @@ using Test, SumTypes
 
 @sum_type Foo begin
     Bar(::Int)
-    Baz(::Float64)
+    Baz(x)
 end
+
 @sum_type Either{A, B} begin
     Left{A}(::A)
     Right{B}(::B)
@@ -49,14 +50,25 @@ end
     
     @test_throws ErrorException either_test_overcomplete(Left(1))
 
-    @test_throws Exception macroexpand(@__MODULE__(), :(@cases x begin
-        Left{Int}(x) => x
-        Right(x) => x
-    end))
-    
-    
-    @test_throws ErrorException either_test_overcomplete(Left(1))
+    @test_throws Exception macroexpand(@__MODULE__(),
+                                       :(@cases x begin
+                                             Left{Int}(x) => x
+                                             Right(x) => x
+                                         end))
 
+    @test_throws Exception macroexpand(@__MODULE__(),
+                                       :(@sum_type Blah begin
+                                             duplicate_field
+                                             duplicate_field
+                                         end))
+
+    
+    @test_throws Exception macroexpand(@__MODULE__(),
+                                       :(@sum_type Blah begin
+                                             duplicate_field
+                                             duplicate_field
+                                         end some_option=false))
+    
     let x = Left([1]), y = Left([1.0]), z = Right([1])
         @test x == y
         @test x != z
@@ -194,6 +206,7 @@ end hide_variants = true
         A => 1
         B => 2
     end
+
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,7 @@ end
         @test x == y
         @test x != z
     end
+    @test SumTypes.get_tag_sym(Left([1])) == :Left
     
     @test_throws MethodError Left{Int}("hi")
     @test_throws MethodError Right{String}(1)


### PR DESCRIPTION
closes #15

This makes it so that we store basically a named tuple instead of the `struct` the user asked for. The memory layout hasn't changed, but this allows recursively defined sum types, and incidentally the benchmark from the README improved. 