### PR TITLE
More `convert` fixes, parameterize on flagtype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - [Basics](https://github.com/MasonProtter/SumTypes.jl#basics)
 - [Destructuring sum types](https://github.com/MasonProtter/SumTypes.jl#destructuring-sum-types)
-- [Using `full_type` to get the concrete type of a Sum Type](https://github.com/MasonProtter/SumTypes.jl/tree/compute-storage#using-full_type-to-get-the-concrete-type-of-a-sum-type)
+- [Using `full_type` to get the concrete type of a Sum Type](https://github.com/MasonProtter/SumTypes.jl/#using-full_type-to-get-the-concrete-type-of-a-sum-type)
 - [Avoiding namespace clutter](https://github.com/MasonProtter/SumTypes.jl#avoiding-namespace-clutter)
 - [Custom printing](https://github.com/MasonProtter/SumTypes.jl#custom-printing)
 - [Performance](https://github.com/MasonProtter/SumTypes.jl#performance)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This is particularly useful because in this case `foo` is
 ``` julia
 julia> Base.return_types(foo, Tuple{})
 1-element Vector{Any}:
- Either{Int64, Float64, 15, 0}
+ Either{Int64, Float64, 8, 0, UInt64}
 
 julia> isconcretetype(ans[1])
 true
@@ -187,13 +187,13 @@ In order to get the proper, concrete type corresponding to `Either{Int, Int}`, o
 
 ``` julia
 julia> full_type(Either{Int, Int})
-Either{Int64, Int64, 15, 0}
+Either{Int64, Int64, 8, 0, UInt64}
 
 julia> full_type(Either{Int, String})
-Either{Int64, String, 8, 1}
+Either{Int64, String, 8, 1, UInt8}
 
 julia> full_type(Either{Tuple{Int, Int, Int}, String})
-Either{Tuple{Int64, Int64, Int64}, String, 24, 1}
+Either{Tuple{Int64, Int64, Int64}, String, 24, 1, UInt8}
 
 julia> isconcretetype(ans)
 true
@@ -400,13 +400,14 @@ end
 
 ```
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  53.120 μs …  64.690 μs  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     54.070 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   54.093 μs ± 425.595 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  52.680 μs …  72.570 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     53.590 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   53.718 μs ± 756.064 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-                ▁ ▂▂▅▇▆█▅▆▃▃                                    
-  ▁▁▁▁▁▂▂▃▄▅▇▅▇▆█▇██████████▇▇▅▅▅▃▃▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
-  53.1 μs         Histogram: frequency by time         55.8 μs <
+        ▁▂▁▃▆▅█▇▅▅▃▁▁                                           
+  ▁▂▂▃▅▆██████████████▇▇▅▄▄▃▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
+  52.7 μs         Histogram: frequency by time         56.7 μs <
+
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 

--- a/README.md
+++ b/README.md
@@ -484,4 +484,3 @@ SumTypes.jl has some other advantages relative to Unityper.jl such as:
 
 One advantage of Unityper.jl is:
 - Because Unityper.jl doesn't allow parameterized types and needs to know all type information at macroexpansion time, their structs have a fixed layout for boxed variables that lets them avoid an allocation when storing heap allocated objects (this allocation would be in addition to the heap allocation for the object itself). If we had used `D(;common_field=1, b="hi")` in our benchmarks, SumTypes.jl could have incurred an allocation whereas Unityper.jl would not. As far as I know, this would requre https://github.com/JuliaLang/julia/issues/8472 in order to avoid in SumTypes.jl
-

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -45,21 +45,26 @@ show_sumtype(io::IO, m::MIME, x) = show_sumtype(io, x)
 function show_sumtype(io::IO, x::T) where {T}
     tag = get_tag(x)
     sym = flag_to_symbol(T, tag)
-    T_stripped = if length(T.parameters) == 2
-        String(T.name.name)
-    else
-        string(String(T.name.name), "{", join(repr.(T.parameters[1:end-2]), ", "), "}")
-    end 
+    T_stripped = T_string_stripped(T)
     if unwrap(x) isa Variant{(), Tuple{}}
         print(io, String(sym), "::", T_stripped)
     else
         print(io, String(sym), '(', join((repr(data) for data ∈ unwrap(x)), ", "), ")::", T_stripped)
     end
 end
+function T_string_stripped(::Type{T}) where {T}
+    @assert is_sumtype(T)
+    T_stripped = if length(T.parameters) == 2
+        String(T.name.name)
+    else
+        string(String(T.name.name), "{", join(repr.(T.parameters[1:end-2]), ", "), "}")
+    end 
+end
+
 
 struct Converter{T, U} end
 (::Converter{T, U})(x) where {T, U} = convert(T, U(x))
-Base.show(io::IO, x::Converter{T, U}) where {T, U} = print(io, "$(T)'.$U")
+Base.show(io::IO, x::Converter{T, U}) where {T, U} = print(io, "$(T_string_stripped(T))'.$U")
 
 
 include("compute_storage.jl")

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -52,8 +52,9 @@ function show_sumtype(io::IO, x::T) where {T}
         print(io, String(sym), '(', join((repr(data) for data ∈ unwrap(x)), ", "), ")::", T_stripped)
     end
 end
-function T_string_stripped(::Type{T}) where {T}
-    @assert is_sumtype(T)
+function T_string_stripped(::Type{_T}) where {_T}
+    @assert is_sumtype(_T)
+    T = full_type(_T)
     T_stripped = if length(T.parameters) == 2
         String(T.name.name)
     else

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -55,10 +55,10 @@ end
 function T_string_stripped(::Type{_T}) where {_T}
     @assert is_sumtype(_T)
     T = full_type(_T)
-    T_stripped = if length(T.parameters) == 2
+    T_stripped = if length(T.parameters) == 3
         String(T.name.name)
     else
-        string(String(T.name.name), "{", join(repr.(T.parameters[1:end-2]), ", "), "}")
+        string(String(T.name.name), "{", join(repr.(T.parameters[1:end-3]), ", "), "}")
     end 
 end
 

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -57,6 +57,11 @@ function show_sumtype(io::IO, x::T) where {T}
     end
 end
 
+struct Converter{T, U} end
+(::Converter{T, U})(x) where {T, U} = convert(T, U(x))
+Base.show(io::IO, x::Converter{T, U}) where {T, U} = print(io, "$(T)'.$U")
+
+
 include("compute_storage.jl")
 include("sum_type.jl") # @sum_type defined here
 include("cases.jl")    # @cases    defined here

--- a/src/compute_storage.jl
+++ b/src/compute_storage.jl
@@ -25,8 +25,8 @@ end
     end
 end
 
-_rf_findmin((fm, im), (fx, ix)) = isless(fx, fm) ? (fx, ix) : (fm, im)
-_argmin(f, domain) = mapfoldl(x -> (f(x), x), _rf_findmin, domain)[2]
+_rf_findmax((fm, im), (fx, ix)) = isless(fm, fx) ? (fx, ix) : (fm, im)
+_argmax(f, domain) = mapfoldl(x -> (f(x), x), _rf_findmax, domain)[2]
 
 function extract_info(::Type{ST}, variants) where {ST}
     
@@ -61,11 +61,11 @@ function extract_info(::Type{ST}, variants) where {ST}
     
     FT = if nptrs == 0
         if bit_size <= 1
-            _argmin(sizeof, (_FT, UInt8))
+            _argmax(sizeof, (_FT, UInt8))
         elseif bit_size <= 2
-            _argmin(sizeof, (_FT, UInt16))
+            _argmax(sizeof, (_FT, UInt16))
         elseif bit_size <= 4
-            _argmin(sizeof, (_FT, UInt32))
+            _argmax(sizeof, (_FT, UInt32))
         else
             UInt
         end

--- a/src/compute_storage.jl
+++ b/src/compute_storage.jl
@@ -25,6 +25,9 @@ end
     end
 end
 
+_rf_findmin((fm, im), (fx, ix)) = isless(fx, fm) ? (fx, ix) : (fm, im)
+_argmin(f, domain) = mapfoldl(x -> (f(x), x), _rf_findmin, domain)[2]
+
 function extract_info(::Type{ST}, variants) where {ST}
     
     data = map(variants) do variant
@@ -58,11 +61,11 @@ function extract_info(::Type{ST}, variants) where {ST}
     
     FT = if nptrs == 0
         if bit_size <= 1
-            argmin(sizeof, (_FT, UInt8))
+            _argmin(sizeof, (_FT, UInt8))
         elseif bit_size <= 2
-            argmin(sizeof, (_FT, UInt16))
+            _argmin(sizeof, (_FT, UInt16))
         elseif bit_size <= 4
-            argmin(sizeof, (_FT, UInt32))
+            _argmin(sizeof, (_FT, UInt32))
         else
             UInt
         end

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -129,6 +129,8 @@ function generate_constructor_data(T_name, T_params, T_params_constrained, T_nam
             push!(constructors, nt)
         end
     end
+    length(constructors) > typemax(UInt32) &&
+        error("Too many variants in SumType, got $(length(constructors)). The current maximum number is $(typemax(UInt32) |> Int)")
     constructors
 end
 
@@ -190,7 +192,7 @@ function generate_constructor_exprs(T_name, T_params, T_params_constrained, T_na
         enumerate_constructors = collect(enumerate(constructors))
 
         if true
-            @gensym N M _tag _T x
+            @gensym N M FT _tag _T x 
 
             if_nest_conv = :(
                 let $_tag = $get_tag(x)
@@ -203,9 +205,9 @@ function generate_constructor_exprs(T_name, T_params, T_params_constrained, T_na
                       $Base.convert(::$Type{$_T}, $x::$_T) where {$_T <: $T_name} = $x
                       $Base.convert(::$Type{<:$T_init}, x::$T_uninit) where {$(T_params...)} = $if_nest_conv 
                       (::$Type{<:$T_init})(x::$T_uninit) where {$(T_params...)} = $if_nest_conv
-                      $Base.convert(::$Type{<:$T_init}, x::$T_uninit{$N, $M}) where {$(T_params...), $N, $M} = $if_nest_conv 
-                      $Base.convert(::$Type{$T_init}, x::$T_uninit{$N, $M}) where {$(T_params...), $N, $M} = $if_nest_conv
-                      (::$Type{<:$_T})(x::$T_name) where {$_T <: $T_name} = $convert($_T, x)
+                      $Base.convert(::$Type{<:$T_init}, x::$T_uninit{$N, $M, $FT}) where {$(T_params...), $N, $M, $FT} = $if_nest_conv 
+                      $Base.convert(::$Type{$T_init}, x::$T_uninit{$N, $M, $FT}) where {$(T_params...), $N, $M, $FT} = $if_nest_conv
+                      (::$Type{$_T})(x::$T_name) where {$_T <: $T_name} = $convert($_T, x)
                   end)
         end
     end
@@ -224,18 +226,17 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_p
     con_names        = (x -> x.name       ).(constructors)
     con_gnames       = (x -> x.gname      ).(constructors)
 
-    flagtype =  length(constructors) < typemax(UInt8) ? UInt8 : length(constructors) < typemax(UInt16) ? UInt16 :
-        length(constructors) <= typemax(UInt32) ? UInt32 :
-        error("Too many variants in SumType, got $(length(constructors)). The current maximum number is $(typemax(UInt32) |> Int)")
-
     N = Symbol("#N#")
     M = Symbol("#M#")
-    T_full = T isa Expr && T.head == :curly ? Expr(:curly, T.args..., N, M) : Expr(:curly, T, N, M)
+    FT = Symbol("#FT#")
+    T_full = T isa Expr && T.head == :curly ? Expr(:curly, T.args..., N, M, FT) : Expr(:curly, T, N, M, FT)
     sum_struct_def = Expr(:struct, false, T_full,
-                          Expr(:block, :(bits :: $NTuple{$N, $UInt8}), :(ptrs :: $NTuple{$M, $Any}), :($tag :: $flagtype), :(1 + 1)))
+                          Expr(:block, :(bits :: $NTuple{$N, $UInt8}), :(ptrs :: $NTuple{$M, $Any}), :($tag :: $FT), :(1 + 1)))
+    
     enumerate_constructors = collect(enumerate(constructors))
+    
     if_nest_unwrap = mapfoldr(((cond, data), old) -> Expr(:if, cond, data, old),  enumerate_constructors, init=:(error("invalid tag"))) do (i, nt)
-        :(tag == $(flagtype(i-1))), :($unwrap(x, $(nt.store_type))) 
+        :(tag == $FT($(i-1))), :($unwrap(x, $(nt.store_type))) 
     end
 
     only_define_with_params = if !isempty(T_params)
@@ -244,28 +245,34 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_p
             $SumTypes.constructors(::Type{<:$T_nameparam}) where {$(T_params...)} =
                 $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.store_type for nt ∈ constructors)...)))
             $Base.adjoint(::Type{<:$T_nameparam}) where {$(T_params...)} =
-                $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.value ? :($T_nameparam($(nt.gname))) : :($Converter{$T_nameparam, $(nt.gouter_type)}()) for nt ∈ constructors)...)))
+                $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.value ? :($T_nameparam($(nt.gname))) : :($Converter{$T_nameparam, $(nt.gouter_type)}())
+                                                            for nt ∈ constructors)...)))
             $SumTypes.variants_Tuple(::Type{<:$T_nameparam}) where {$(T_params...)} =
                 $Tuple{$((nt.store_type for nt ∈ constructors)...)}
-            $SumTypes.full_type(::Type{$T_name}) = $full_type($T_name{$(T_param_bounds...)}, $variants_Tuple($T_nameparam{$(T_param_bounds...)}))
+            $SumTypes.full_type(::Type{$T_name}) = $full_type($T_name{$(T_param_bounds...)}, $variants_Tuple($T_name{$(T_param_bounds...)}))
         end
     end
+    # @show only_define_with_params
 
+    @gensym _T
+    
     ex = quote
         $sum_struct_def
         $SumTypes.is_sumtype(::Type{<:$T_name}) = true
-        $SumTypes.strip_size_params(::Type{$T_name{$(T_params...), $N, $M}}) where {$(T_params...), $N, $M} = $T_nameparam
-        $SumTypes.flagtype(::Type{<:$T_name}) = $flagtype
+        $SumTypes.strip_size_params(::Type{$T_name{$(T_params...), $N, $M, $FT}}) where {$(T_params...), $N, $M, $FT} = $T_nameparam
+        $SumTypes.flagtype(::Type{$_T}) where {$_T <: $T_name} = $flagtype(full_type($_T))
+        $SumTypes.flagtype(::Type{$T_name{$(T_params...), $N, $M, $FT}}) where {$(T_params...), $N, $M, $FT} = $FT
         
-        $SumTypes.symbol_to_flag(::Type{<:$T_name}, sym::Symbol) =
+        $SumTypes.symbol_to_flag(::Type{$_T}, sym::Symbol) where {$_T <: $T_name} =
             $(foldr(collect(enumerate(con_names)), init=:(error("Invalid tag symbol $sym"))) do (i, _sym), old
-                  Expr(:if, :(sym == $(QuoteNode(_sym))), flagtype(i-1), old)
+                  Expr(:if, :(sym == $(QuoteNode(_sym))), :($flagtype($_T)($(i-1))), old)
               end)
-        $SumTypes.flag_to_symbol(::Type{<:$T_name}, flag::$flagtype) =
+        $SumTypes.flag_to_symbol(::Type{<:$T_name}, flag::$Integer) =
             $(foldr(collect(enumerate(con_names)), init=:(error("Invalid tag symbol $sym"))) do (i, sym), old
                   Expr(:if, :(flag == $(i-1)), QuoteNode(sym), old)
               end)
-        $SumTypes.tags_flags_nt(::Type{<:$T_name}) = $(Expr(:tuple, Expr(:parameters, (Expr(:kw, name, flagtype(i)) for (i, name) ∈ enumerate(con_names))...)))
+        $SumTypes.tags_flags_nt(::Type{<:$_T}) where {$_T <: $T_name} =
+            $(Expr(:tuple, Expr(:parameters, (Expr(:kw, name, :($flagtype($_T)($(i-1)))) for (i, name) ∈ enumerate(con_names))...)))
         $SumTypes.tags(::Type{<:$T_name}) = $(Expr(:tuple, map(x -> QuoteNode(x.name), constructors)...))
         
         $SumTypes.constructors(::Type{<:$T_name}) =
@@ -274,20 +281,20 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_p
         $SumTypes.variants_Tuple(::Type{<:$T_name}) =
             $Tuple{$((nt.store_type_uninit for nt ∈ constructors)...)}
         
-        $SumTypes.unwrap(x::$T_nameparam) where {$(T_params...)}= let tag = $get_tag(x)
+        $SumTypes.unwrap(x::$T_nameparam{$N, $M, $FT}) where {$(T_params...), $N, $M, $FT}= let tag = $get_tag(x)
             $if_nest_unwrap
         end
         $Base.adjoint(::Type{<:$T_name}) =
             $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.gname  for nt ∈ constructors)...)))
 
         $SumTypes.full_type(::Type{$T_nameparam}) where {$(T_params...)} = $full_type($T_nameparam, $variants_Tuple($T_nameparam))
-        $SumTypes.full_type(::Type{$T_nameparam{$N, $M}}) where {$(T_params...), $N, $M} = $T_nameparam{$N, $M}
+        $SumTypes.full_type(::Type{$T_nameparam{$N, $M, $FT}}) where {$(T_params...), $N, $M, $FT} = $T_nameparam{$N, $M, $FT}
         
         $Base.show(io::IO, x::$T_name) = $show_sumtype(io, x)
         $Base.show(io::IO, m::MIME"text/plain", x::$T_name) = $show_sumtype(io, m, x)
 
         Base.:(==)(x::$T_name, y::$T_name) = ($get_tag(x) == $get_tag(y)) && ($unwrap(x) == $unwrap(y))
-        $only_define_with_params 
+        $only_define_with_params
     end
     foreach(constructors) do nt
         con1 = :($SumTypes.constructor(::Type{<:$T_name}, ::Type{Val{$(QuoteNode(nt.name))}}) = $(nt.store_type_uninit))

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -281,6 +281,7 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_p
             $NamedTuple{$tags($T_name)}($(Expr(:tuple, (nt.gname  for nt ∈ constructors)...)))
 
         $SumTypes.full_type(::Type{$T_nameparam}) where {$(T_params...)} = $full_type($T_nameparam, $variants_Tuple($T_nameparam))
+        $SumTypes.full_type(::Type{$T_nameparam{$N, $M}}) where {$(T_params...), $N, $M} = $T_nameparam{$N, $M}
         
         $Base.show(io::IO, x::$T_name) = $show_sumtype(io, x)
         $Base.show(io::IO, m::MIME"text/plain", x::$T_name) = $show_sumtype(io, m, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,8 +86,8 @@ end
     @test convert(full_type(Either{Int, Int}), Left(1))  == Left(1)
     @test convert(full_type(Either{Int, Int}), Left(1)) !== Left(1)
     @test convert(full_type(Either{Int, Int}), Left(1)) === Either{Int, Int}'.Left(1)
-    @inferred Either{Int, Int, 15, 0} Either{Int, Int, 15, 0}(Left(1))
-    @inferred Either{Int, Int, 15, 0} Either{Int, Int, 15, 0}(Either{Int, Int}(Left(1)))
+    @test Either{Int, Int, 15, 0}(Left(1)) isa Either{Int, Int, 15, 0}
+    @test Either{Int, Int, 15, 0}(Either{Int, Int}(Left(1))) isa Either{Int, Int, 15, 0}
     
     @test_throws MethodError Left{Int}("hi")
     @test_throws MethodError Right{String}(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,9 @@ end
     @test full_type(Either{Nothing, Nothing}) == Either{Nothing, Nothing, 0, 0, UInt8}
     @test full_type(Either{Int, Int}) == Either{Int, Int, 8, 0, UInt}
     @test full_type(Either{Int, String}) == Either{Int, String, 8, 1, UInt8}
+
+    @test full_type(Either{Nothing, Int16}) == Either{Nothing, Int16, 2, 0, UInt16}
+    @test full_type(Either{Int32, Int32}) == Either{Int32, Int32, 4, 0, UInt32}
 end
 
 #--------------------------------------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,12 @@ end
         @test x != z
     end
     @test SumTypes.get_tag_sym(Left([1])) == :Left
+
+    @test convert(full_type(Either{Int, Int}), Left(1))  == Left(1)
+    @test convert(full_type(Either{Int, Int}), Left(1)) !== Left(1)
+    @test convert(full_type(Either{Int, Int}), Left(1)) === Either{Int, Int}'.Left(1)
+    @inferred Either{Int, Int, 15, 0} Either{Int, Int, 15, 0}(Left(1))
+    @inferred Either{Int, Int, 15, 0} Either{Int, Int, 15, 0}(Either{Int, Int}(Left(1)))
     
     @test_throws MethodError Left{Int}("hi")
     @test_throws MethodError Right{String}(1)
@@ -254,5 +260,6 @@ end
         @test repr(Right(3)) == "R(3)"
     end
     @test repr(apple) == "apple::Fruit"
+    @test repr(Either{Int, Int}'.Left) ∈ ("Either{Int64, Int64}'.Left{Int64}", "Either{Int64,Int64}'.Left{Int64}")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,16 +101,16 @@ end
     @test convert(full_type(Either{Int, Int}), Left(1))  == Left(1)
     @test convert(full_type(Either{Int, Int}), Left(1)) !== Left(1)
     @test convert(full_type(Either{Int, Int}), Left(1)) === Either{Int, Int}'.Left(1)
-    @test Either{Int, Int, 15, 0}(Left(1)) isa Either{Int, Int, 15, 0}
-    @test Either{Int, Int, 15, 0}(Either{Int, Int}(Left(1))) isa Either{Int, Int, 15, 0}
+    @test Either{Int, Int, 8, 0, UInt}(Left(1)) isa Either{Int, Int, 8, 0, UInt}
+    @test Either{Int, Int, 8, 0, UInt}(Either{Int, Int}(Left(1))) isa Either{Int, Int, 8, 0, UInt}
     
     @test_throws MethodError Left{Int}("hi")
     @test_throws MethodError Right{String}(1)
     @test Left{Int}(0x01) === Left{Int}(1)
 
-    @test full_type(Either{Nothing, Nothing}) == Either{Nothing, Nothing, 0, 0}
-    @test full_type(Either{Int, Int}) == Either{Int, Int, 15, 0}
-    @test full_type(Either{Int, String}) == Either{Int, String, 8, 1}
+    @test full_type(Either{Nothing, Nothing}) == Either{Nothing, Nothing, 0, 0, UInt8}
+    @test full_type(Either{Int, Int}) == Either{Int, Int, 8, 0, UInt}
+    @test full_type(Either{Int, String}) == Either{Int, String, 8, 1, UInt8}
 end
 
 #--------------------------------------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,18 @@ end
     Right{B}(::B)
 end
 
+@sum_type Result{T} begin
+    Failure
+    Success{T}(::T)
+end
+
+function log_nothrow(x::T)::Result{T} where{T<:AbstractFloat}
+  if x < zero(x) 
+      return Failure
+  end
+  Success(log(x))
+end
+
 #-------------------
 @testset "Basics  " begin
     @test SumTypes.is_sumtype(Int) == false
@@ -49,6 +61,9 @@ end
     end
     
     @test_throws ErrorException either_test_overcomplete(Left(1))
+
+    @test log_nothrow(1.0) == Success(0.0)
+    @test log_nothrow(-1.0) == Failure
 
     @test_throws Exception macroexpand(@__MODULE__(),
                                        :(@cases x begin


### PR DESCRIPTION
Ref: https://discourse.julialang.org/t/ann-sumtypes-jl-v0-4/97038/7

Before:
```julia
using SumTypes, BenchmarkTools

@sum_type Result{T} begin
  Failure
  Success{T}(::T)
end

# If I annotate the return type here as ::Result{T}, this function throws an
# ambiguous method error.
function log_nothrow(x::T) where{T<:AbstractFloat}
  if x < zero(x) 
    # Because I can't annotate the return type, using the other README trick.
    f::Result{T} = Failure
    return f
  end
  Success(log(x))
end

julia> @benchmark log_nothrow($(1.1))
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  15.360 ns … 25.671 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     15.371 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.394 ns ±  0.168 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃    █         ▂                                             
  █▁▁▁▃█▁▁▁▂▃▁▁▁▂█▁▁▁▆▁▁▁▁▂▁▁▁▁▂▁▁▁▁▂▁▁▁▁▂▁▁▁▂▅▁▁▁▂▂▁▁▁▂▃▁▁▁▃ ▂
  15.4 ns         Histogram: frequency by time        15.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

After:
```julia
function log_nothrow(x::T)::Result{T} where{T<:AbstractFloat}
  if x < zero(x) 
      return Failure
  end
  Success(log(x))
end

julia> @benchmark log_nothrow(1.1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  1.080 ns … 4.470 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.090 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.090 ns ± 0.038 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                              █                              
  ▅▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂ ▂
  1.08 ns        Histogram: frequency by time        1.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
(the slowdown in the other way of writing it was also fixed):
```julia
julia> function log_nothrow(x::T) where{T<:AbstractFloat}
         if x < zero(x) 
           # Because I can't annotate the return type, using the other README trick.
           f::Result{T} = Failure
           return f
         end
         Success(log(x))
       end
log_nothrow (generic function with 1 method)

julia> @benchmark log_nothrow(1.1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  1.079 ns … 2.770 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.090 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.088 ns ± 0.034 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▂                                                  █  
  ▂▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁█ ▂
  1.08 ns        Histogram: frequency by time       1.09 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
_________________________

After adding some convert methods, there's still a performance loss due to alignment difficulties:
Before
```julia
julia> let x = Ref(1.1)
           @btime log_nothrow($x[])
           @btime log($x[])
       end
  15.280 ns (0 allocations: 0 bytes)
  4.740 ns (0 allocations: 0 bytes)
0.09531017980432493
```

I've now changed things so that the size of the discriminator byte actually changes to ensure that julia makes good alignment choices. This required the sum type to be parameterized on the flagtype as well, which is unfortunate but does work:
```julia
julia> let x = Ref(1.1)
           @btime log_nothrow($x[])
           @btime log($x[])
       end
  5.220 ns (0 allocations: 0 bytes)
  4.740 ns (0 allocations: 0 bytes)
0.09531017980432493
```