### PR TITLE
Add some quasi-internal API nicities

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,8 @@ jobs:
         version:
           - '1.1'
           - '1.6'
-          - '1.8'		  
+          - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -21,6 +21,22 @@ function variants_Tuple end
 function strip_size_params end
 function full_type end
 
+"""
+    isvariant(x::SumType, s::Symbol)
+
+For an `x` which was created as a `@sum_type`, check if it's variant tag is `s`. e.g.
+
+    @sum_type Either{L, R} begin
+        Left{L}(::L)
+        Right{R}(::R)
+    end
+
+    let x::Either{Int, Int} = Left(1)
+        isvariant(x, :Left)  # true
+        isvariant(x, :Right) # false
+    end
+"""
+isvariant(x::T, s::Symbol) where {T} = get_tag(x) == symbol_to_flag(T, s)
 
 struct Unsafe end
 const unsafe = Unsafe()
@@ -36,6 +52,7 @@ Base.:(==)(v1::Variant, v2::Variant) = v1.data == v2.data
 
 Base.iterate(x::Variant, s = 1) = iterate(x.data, s)
 Base.indexed_iterate(x::Variant, i::Int, state=1) = (Base.@_inline_meta; (getfield(x.data, i), i+1))
+Base.getindex(x::Variant, i) = x.data[i]
 
 const tag = Symbol("#tag#")
 get_tag(x) = getfield(x, tag)

--- a/src/cases.jl
+++ b/src/cases.jl
@@ -56,7 +56,7 @@ macro cases(to_match, block)
     @gensym nt
     variants = map(x -> x.variant, stmts)
     
-    ex = :(if $get_tag($data) === $symbol_to_flag($Typ, $(QuoteNode(stmts[1].variant)));
+    ex = :(if $isvariant($data, $(QuoteNode(stmts[1].variant)));
                $(stmts[1].iscall ? :(($(stmts[1].fieldnames...),) =
                    $unwrap($data, $constructor($Typ, $Val{$(QuoteNode(stmts[1].variant))}), $variants_Tuple($Typ))  ) : nothing);
                $(stmts[1].rhs)
@@ -65,7 +65,7 @@ macro cases(to_match, block)
     pushfirst!(ex.args[2].args, lnns[1])
     to_push = ex.args
     for i ∈ 2:length(stmts)
-        _if = :(if $get_tag($data) === $symbol_to_flag($Typ, $(QuoteNode(stmts[i].variant)));
+        _if = :(if $isvariant($data, $(QuoteNode(stmts[i].variant)));
                     $(stmts[i].iscall ? :(($(stmts[i].fieldnames...),) =
                         $unwrap($data, $constructor($Typ, $Val{$(QuoteNode(stmts[i].variant))}), $variants_Tuple($Typ))) : nothing);
                     $(stmts[i].rhs)
@@ -87,4 +87,3 @@ macro cases(to_match, block)
         end
     end |> esc
 end
-

--- a/src/compute_storage.jl
+++ b/src/compute_storage.jl
@@ -109,6 +109,11 @@ make(::Type{ST}, to_make, tag) where {ST} = make(ST, to_make, tag, variants_Tupl
     )
 end
 
+
+function unwrap(x::ST, s::Symbol) where {ST}
+    isvariant(x, s) || error("Incorrect tag used in unwrap")
+    unwrap(x, constructor(ST, Val{s}), variants_Tuple(ST))
+end
 unwrap(x::ST, var) where {ST} = unwrap(x, var, variants_Tuple(ST))
 @generated function unwrap(x::ST, ::Type{Var}, ::Type{var_Tuple}) where {ST, Var, var_Tuple}
     variants = var_Tuple.parameters

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -260,7 +260,7 @@ function generate_sum_struct_expr(T, T_name, T_params, T_params_constrained, T_p
         $sum_struct_def
         $SumTypes.is_sumtype(::Type{<:$T_name}) = true
         $SumTypes.strip_size_params(::Type{$T_name{$(T_params...), $N, $M, $FT}}) where {$(T_params...), $N, $M, $FT} = $T_nameparam
-        $SumTypes.flagtype(::Type{$_T}) where {$_T <: $T_name} = $flagtype(full_type($_T))
+        $SumTypes.flagtype(::Type{$_T}) where {$_T <: $T_name} = $flagtype($full_type($_T))
         $SumTypes.flagtype(::Type{$T_name{$(T_params...), $N, $M, $FT}}) where {$(T_params...), $N, $M, $FT} = $FT
         
         $SumTypes.symbol_to_flag(::Type{$_T}, sym::Symbol) where {$_T <: $T_name} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,12 @@ end
     @test full_type(Either{Nothing, Int16}) == Either{Nothing, Int16, 2, 0, UInt16}
     @test full_type(Either{Int32, Int32}) == Either{Int32, Int32, 4, 0, UInt32}
     @test convert(full_type(Result{Float64}), Success(1.0)) == Success(1.0)
+
+    let x = Left(1.0)
+        @test SumTypes.isvariant(x, :Left) == true
+        @test SumTypes.isvariant(x, :Right) == false
+        @test SumTypes.unwrap(x, :Left)[1] == 1.0
+    end
 end
 
 #--------------------------------------------------------


### PR DESCRIPTION
This PR adds
1. `isvariant(x::SumType, s::Symbol)` for testing if a sumtype is a specific variant by name. Closes #35 
2. `getindex(v::Variant, i)` Closes #34 
3. `unwrap(x::SumType, s::Symbol)` (this shouldn't be used unless you really need it, the correct way to unwrap sumtypes is with `@cases`)