### PR TITLE
Some fixes for type constrained parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.4.5"
+version = "0.4.6"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ end
     Right{B}(::B)
 end
 
-@sum_type Result{T} begin
+@sum_type Result{T <: Union{Number, Uninit}} begin
     Failure
     Success{T}(::T)
 end
@@ -314,3 +314,14 @@ end
     @test repr(Either{Int, Int}'.Left) ∈ ("Either{Int64, Int64}'.Left{Int64}", "Either{Int64,Int64}'.Left{Int64}")
 end
 
+#---------------
+# https://github.com/MasonProtter/SumTypes.jl/issues/38
+struct Singleton end
+@testset "Constrained type parameters" begin
+    @sum_type FooWrapper{T<:Singleton} begin
+        FooWrapper1{T}(::T)
+        FooWrapper2{T}(::T)
+        FooWrapper3{T}(::T)
+    end
+    @test FooWrapper2(Singleton()) isa FooWrapper{Singleton}
+end


### PR DESCRIPTION
Should fix https://github.com/MasonProtter/SumTypes.jl/issues/38, but there's probably still remaining bugs to squash when someone puts constraints on type parameters in sum types. 