### PR TITLE
Scope SumType to defining module

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -343,3 +343,28 @@ end;
 end
 
 end
+
+module ModuleScopedSumTypes 
+
+using SumTypes, Test 
+
+@sum_type Foo begin
+    A1(::String)
+    B(::Float64)
+    C1(::String)
+    D(::Pair{Symbol, Int})
+end
+
+foo(x::Foo) = @cases x begin
+    [A1, B](x) => x
+    C1(s)         => parse(Int, s)
+    D((_, x))    => x
+end
+
+@testset "Module scoped sum types" begin
+    @test foo(A1("abc")) == "abc"
+    @test foo(B(1.5)) == 1.5
+    @test foo(C1("3")) == 3
+    @test foo(D(:a => 4)) == 4
+end
+end


### PR DESCRIPTION
This small PR qualifies the type expression used to define SumType metadata to the module which defines the type.

This allows the same named type to exist in different modules, e.g., `Module1.A` and `Module2.A` can exist with two entirely different definitions without issue.