### PR TITLE
allow `_` as the fallback 'wildcard' case

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
           - '1.6'
           - '1.8'
           - '1.9'
+          - '1.10.0-rc1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ The `@cases` macro still falls far short of a full on pattern matching system, l
 
 ### Defining many repetitive cases simultaneously 
 
-`@cases` does not allow for fallback branches, and it also does not allow one to write inexhaustive cases. To avoid making some code overly verbose and repetitive, we instead provide syntax for defining many cases in one line:
-
+Generally, it's good to explicitly handle all cases of a sum type, but sometimes you just want one set of behaviour for
+a large set of cases. One option, is 'collections' of cases like so:
 ``` julia
 @sum_type Re begin
     Empty
@@ -207,6 +207,16 @@ count_classes(r::Re, c=0) = @cases r begin
     Rep(x) => c + count_classes(x)
    [Alt, Cat, Diff, And](x, y)  => c + count_classes(x) + count_classes(y)
 end;
+```
+
+SumTypes also lets you use `_` as a case predicate that accepts anything, but this only works in the final position, and
+does not allow destructuring:
+
+``` julia
+isEmpty(x::Re) = @cases x begin
+    Empty => true
+    _     => false
+end
 ```
 
 <!-- </details> -->

--- a/src/cases.jl
+++ b/src/cases.jl
@@ -19,7 +19,11 @@
 end
 
 macro cases(to_match, block)
-    @assert block.head == :block
+    esc(_cases(to_match, block))
+end
+
+function _cases(to_match, block) 
+    block.head == :block || error("The second argument to @cases must be a code block")
     lnns = filter(block.args) do arg
         arg isa LineNumberNode
     end
@@ -32,7 +36,7 @@ macro cases(to_match, block)
         if arg isa LineNumberNode
             return nothing
         end
-        arg.head == :call && arg.args[1] == :(=>) || throw(error("Malformed case $arg"))
+        arg.head == :call && arg.args[1] == :(=>) || error("Malformed case $arg")
         lhs = arg.args[2]
         rhs = arg.args[3]
         if isexpr(lhs, :call) # arg.args[2] isa Expr && arg.args[2].head == :call
@@ -115,5 +119,5 @@ macro cases(to_match, block)
             $unwrapped = $unwrap($data)
             $ex
         end
-    end |> esc
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,7 +99,24 @@ Base.getproperty(f::Result, s::Symbol) = error("Don't do that!")
     @test_throws Exception SumTypes._sum_type(
         :(Blah{T}), :(begin
                          foo{U}(::U)
-                     end ))
+                      end ))
+    @test_throws Exception SumTypes._cases(:(Fruit), :(1))
+    @test_throws Exception SumTypes._cases(:(Fruit), :([1, 2, 3]))
+    @test_throws Exception SumTypes._cases(:(Fruit), :(begin
+                                                       true
+                                                       _ => false
+                                                       banana => false
+                                                       end))
+    @test_throws Exception SumTypes._cases(:(Fruit), :(begin
+                                                       apple => true
+                                                       _ => false
+                                                       banana => false
+                                                       end))
+    @test_throws Exception SumTypes._cases(:(Fruit), :(begin
+                                                       apple => true
+                                                       [banana, orange()] => false
+                                                       _ => false
+                                                       end))
     
     let x = Left([1]), y = Left([1.0]), z = Right([1])
         @test x == y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,10 +320,10 @@ end
     Empty
     Class(::UInt8)
     Rep(::Re)
-    Alt(::Re, ::Re)
-    Cat(::Re, ::Re)
+    Alt(::Re,  ::Re)
+    Cat(::Re,  ::Re)
     Diff(::Re, ::Re)
-    And(::Re, ::Re)
+    And(::Re,  ::Re)
 end;
 
 count_classes(r::Re, c=0) = @cases r begin
@@ -332,7 +332,12 @@ count_classes(r::Re, c=0) = @cases r begin
     Rep(x) => c + count_classes(x)
     [Alt, Cat, Diff, And](x, y)  => c + count_classes(x) + count_classes(y)
 end;
-  
+
+is_empty(r::Re) = @cases r begin
+    Empty => true
+    _     => false
+end
+
 @testset "Collection of variants" begin
     @test foo(A(1, 1)) == 2
     @test foo(B(1, 1.5)) == 2.5
@@ -340,6 +345,11 @@ end;
     @test foo(D(:a => 4)) == 4
 
     @test count_classes(And(Alt(Rep(Class(0x1)), And(Class(0x1), Empty)), Class(0x0))) == 3
+
+    @test is_empty(Empty)
+    for r ∈ (Class(1), Rep(Class(1)), Alt(Empty, Empty), Cat(Empty, Empty), Diff(Empty, Empty), And(Empty, Empty))
+        @test !is_empty(r)
+    end
 end
 
 end


### PR DESCRIPTION
Closes https://github.com/MasonProtter/SumTypes.jl/issues/55

With this change, we can now do
```julia
julia> is_apple(f::Fruit) = @cases f begin
           apple => true
           _ => false
       end
is_apple (generic function with 1 method)

julia> is_apple(apple)
true

julia> is_apple(mango)
false
```
```julia

julia> code_typed(is_apple, Tuple{Fruit})
1-element Vector{Any}:
 CodeInfo(
1 ─ %1 = (getfield)(f, :data)::Union{SumTypes.Variant{:apple, (), Tuple{}}, SumTypes.Variant{:banana, (), Tuple{}}, SumTypes.Variant{:orange, (), Tuple{}}, SumTypes.Variant{:kiwi, (), Tuple{}}, SumTypes.Variant{:pear, (), Tuple{}}, SumTypes.Variant{:mango, (), Tuple{}}}
│   %2 = (%1 isa SumTypes.Variant{:apple})::Bool
└──      goto #3 if not %2
2 ─      return true
3 ─      return false
) => Bool
```
