### PR TITLE
remove unnecessary usage of `Expr(:toplevel)`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.1'
           - '1.6'
           - '1.8'
           - '1.9'

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.5.6"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-julia = "1.1"
+julia = "1.6"
 MacroTools = "0.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SumTypes"
 uuid = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -3,7 +3,6 @@ module SumTypes
 export @sum_type, @cases, Uninit, full_type
 
 using MacroTools: MacroTools
-using Base: isexpr
 
 function constructors end
 function constructor end
@@ -13,6 +12,8 @@ is_sumtype(::Type{T}) where {T}   = false
 
 function get_tag end
 function tags end
+
+isexpr(x, head) = x isa Expr && x.head == head
 
 """
     isvariant(x::SumType, s::Symbol)

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -3,6 +3,7 @@ module SumTypes
 export @sum_type, @cases, Uninit, full_type
 
 using MacroTools: MacroTools
+using Base: isexpr
 
 function constructors end
 function constructor end
@@ -12,8 +13,6 @@ is_sumtype(::Type{T}) where {T}   = false
 
 function get_tag end
 function tags end
-
-isexpr(x, head) = x isa Expr && x.head == head
 
 """
     isvariant(x::SumType, s::Symbol)

--- a/src/sum_type.jl
+++ b/src/sum_type.jl
@@ -36,7 +36,7 @@ function _sum_type(T, hidden, blk)
 
     con_expr, con_structs = generate_constructor_exprs(T_name, T_params, T_params_constrained, T_nameparam, constructors)
     out = generate_sum_struct_expr(T, T_abstract, T_name, T_params, T_params_constrained, T_param_bounds, T_nameparam, constructors)
-    Expr(:toplevel, con_structs, out, con_expr) 
+    Expr(:block, con_structs, out, con_expr) 
 end
 
 #------------------------------------------------------
@@ -143,7 +143,7 @@ end
 #------------------------------------------------------
 
 function generate_constructor_exprs(T_name, T_params, T_params_constrained, T_nameparam, constructors)
-    out = Expr(:toplevel)
+    out = Expr(:block)
     converts = []
     con_structs = Expr(:block)
     @gensym _tag _T x 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -375,4 +375,20 @@ end
     end
 end
 
+#-------------------------------
+
+
+@testset "Weird toplevel stuff" begin
+    # https://github.com/MasonProtter/SumTypes.jl/issues/67
+    @test @eval begin
+        mutable struct A{X}
+            x::X
+        end
+        @sum_type B{X} begin
+            C{X}(a::A{X})
+        end
+        true
+    end
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -377,7 +377,8 @@ end
 
 #-------------------------------
 
-
+module ToplevelTest
+using Test, SumTypes
 @testset "Weird toplevel stuff" begin
     # https://github.com/MasonProtter/SumTypes.jl/issues/67
     @test @eval begin
@@ -390,5 +391,6 @@ end
         true
     end
 end
+end 
 
 end


### PR DESCRIPTION
Fixes #67 

I think the stuff with `:toplevel` was sticking around from a previous iteration where it was needed, but that's no longer the case.