### PR TITLE
Add a precompilation workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.5.6"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 julia = "1.6"
 MacroTools = "0.5"
+PrecompileTools = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/SumTypes.jl
+++ b/src/SumTypes.jl
@@ -66,6 +66,6 @@ Base.show(io::IO, x::Converter{T, U}) where {T, U} = print(io, "$T'.$U")
 
 include("sum_type.jl") # @sum_type defined here
 include("cases.jl")    # @cases    defined here
-
+include("precompile.jl")
 
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,28 +2,28 @@
 using PrecompileTools
 
 @setup_workload begin
-    @compile_workload begin
-    	blk = :(begin 
-    				Bar(::Int) 
-    				Baz(x) 
-    			end)
-        _sum_type(:(Foo <: AbstractFoo), QuoteNode(:visible), blk)
-        blk = :(begin
-           			B{X}(a::X)
-          			C{X}(b::X)
-       			end)
-        _sum_type(:(A{X<:Union{Real, SumTypes.Uninit}}), QuoteNode(:visible), blk)
-        blk = :(begin
-				    A(common_field::Int, a::Bool, b::Int)
-				    B(common_field::Int, a::Int, b::Float64, d::Complex{Float64})
-				    C(common_field::Int, b::Float64, d::Bool, e::Float64, k::Complex{Float64})
-				    D(common_field::Int, b::Char)
-    			end)
-    	_sum_type(:(AT), QuoteNode(:visible), blk)
-    	blk = :(begin
-    				Left{A}(::A)
-    				Right{B}(::B)
+	@compile_workload begin
+		blk = :(begin 
+					Bar(::Int) 
+					Baz(x) 
 				end)
-    	_sum_type(:(Either2{A, B}), QuoteNode(:hidden), blk)
-    end
+		_sum_type(:(Foo <: AbstractFoo), QuoteNode(:visible), blk)
+		blk = :(begin
+		   			B{X}(a::X)
+		  			C{X}(b::X)
+	   			end)
+		_sum_type(:(A{X<:Union{Real, SumTypes.Uninit}}), QuoteNode(:visible), blk)
+		blk = :(begin
+					A(common_field::Int, a::Bool, b::Int)
+					B(common_field::Int, a::Int, b::Float64, d::Complex{Float64})
+					C(common_field::Int, b::Float64, d::Bool, e::Float64, k::Complex{Float64})
+					D(common_field::Int, b::Char)
+				end)
+		_sum_type(:(AT), QuoteNode(:visible), blk)
+		blk = :(begin
+					Left{A}(::A)
+					Right{B}(::B)
+				end)
+		_sum_type(:(Either2{A, B}), QuoteNode(:hidden), blk)
+	end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,29 @@
+
+using PrecompileTools
+
+@setup_workload begin
+    @compile_workload begin
+    	blk = :(begin 
+    				Bar(::Int) 
+    				Baz(x) 
+    			end)
+        _sum_type(:(Foo <: AbstractFoo), QuoteNode(:visible), blk)
+        blk = :(begin
+           			B{X}(a::X)
+          			C{X}(b::X)
+       			end)
+        _sum_type(:(A{X<:Union{Real, SumTypes.Uninit}}), QuoteNode(:visible), blk)
+        blk = :(begin
+				    A(common_field::Int, a::Bool, b::Int)
+				    B(common_field::Int, a::Int, b::Float64, d::Complex{Float64})
+				    C(common_field::Int, b::Float64, d::Bool, e::Float64, k::Complex{Float64})
+				    D(common_field::Int, b::Char)
+    			end)
+    	_sum_type(:(AT), QuoteNode(:visible), blk)
+    	blk = :(begin
+    				Left{A}(::A)
+    				Right{B}(::B)
+				end)
+    	_sum_type(:(Either2{A, B}), QuoteNode(:hidden), blk)
+    end
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,28 +2,28 @@
 using PrecompileTools
 
 @setup_workload begin
-	@compile_workload begin
-		blk = :(begin 
-					Bar(::Int) 
-					Baz(x) 
-				end)
-		_sum_type(:(Foo <: AbstractFoo), QuoteNode(:visible), blk)
-		blk = :(begin
-		   			B{X}(a::X)
-		  			C{X}(b::X)
-	   			end)
-		_sum_type(:(A{X<:Union{Real, SumTypes.Uninit}}), QuoteNode(:visible), blk)
-		blk = :(begin
-					A(common_field::Int, a::Bool, b::Int)
-					B(common_field::Int, a::Int, b::Float64, d::Complex{Float64})
-					C(common_field::Int, b::Float64, d::Bool, e::Float64, k::Complex{Float64})
-					D(common_field::Int, b::Char)
-				end)
-		_sum_type(:(AT), QuoteNode(:visible), blk)
-		blk = :(begin
-					Left{A}(::A)
-					Right{B}(::B)
-				end)
-		_sum_type(:(Either2{A, B}), QuoteNode(:hidden), blk)
-	end
+    @compile_workload begin
+        blk = :(begin 
+                    Bar(::Int) 
+                    Baz(x) 
+                end)
+        _sum_type(:(Foo <: AbstractFoo), QuoteNode(:visible), blk)
+        blk = :(begin
+                    B{X}(a::X)
+                    C{X}(b::X)
+                end)
+        _sum_type(:(A{X<:Union{Real, SumTypes.Uninit}}), QuoteNode(:visible), blk)
+        blk = :(begin
+                    A(common_field::Int, a::Bool, b::Int)
+                    B(common_field::Int, a::Int, b::Float64, d::Complex{Float64})
+                    C(common_field::Int, b::Float64, d::Bool, e::Float64, k::Complex{Float64})
+                    D(common_field::Int, b::Char)
+                end)
+        _sum_type(:(AT), QuoteNode(:visible), blk)
+        blk = :(begin
+                    Left{A}(::A)
+                    Right{B}(::B)
+                end)
+        _sum_type(:(Either2{A, B}), QuoteNode(:hidden), blk)
+    end
 end


### PR DESCRIPTION
This cuts down the precompilation time quite a bit:

before:

```julia
julia> using SumTypes

julia> @time @eval @sum_type Re begin
           Empty
           Class(::UInt8)
           Rep(::Re)
           Alt(::Re,  ::Re)
           Cat(::Re,  ::Re)
           Diff(::Re, ::Re)
           And(::Re,  ::Re)
       end;
  1.448841 seconds (2.26 M allocations: 152.786 MiB, 3.72% gc time, 98.11% compilation time)

```

after:

```julia
julia> using SumTypes

julia> @time @eval @sum_type Re begin
           Empty
           Class(::UInt8)
           Rep(::Re)
           Alt(::Re,  ::Re)
           Cat(::Re,  ::Re)
           Diff(::Re, ::Re)
           And(::Re,  ::Re)
       end;
  0.142083 seconds (41.50 k allocations: 2.622 MiB, 82.27% compilation time)
```