### PR TITLE
Change link to DynamicSumTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ If you overload `Base.show` directly inside a package, you might get annoying me
 
 ## Alternative syntax
 
-See also [MixedStructTypes.jl](https://github.com/JuliaDynamics/MixedStructTypes.jl) for an alternative syntax for defining sum types, and some other niceties.
+See also [DynamicSumTypes.jl](https://github.com/JuliaDynamics/DynamicSumTypes.jl) for an alternative syntax for defining sum types, and some other niceties.
 
 ## Performance
 


### PR DESCRIPTION
I changed the name of the package sometime ago, then I remembered its reference here