### PR TITLE
Change link to WrappedUnions.jl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ If you overload `Base.show` directly inside a package, you might get annoying me
 
 ## Alternative syntax
 
-See also [LightSumTypes.jl](https://github.com/JuliaDynamics/LightSumTypes.jl) for an alternative syntax for defining sum types, and some other niceties.
+See also [WrappedUnions.jl](https://github.com/Tortar/WrappedUnions.jl) for an alternative syntax for defining sum types, and some other niceties.
 
 ## Performance
 


### PR DESCRIPTION
Hi @MasonProtter, I remember that you pushed for a name like this in the past :-)

 [LightSumTypes.jl](https://github.com/JuliaDynamics/LightSumTypes.jl) is still named the same, but I created a new package (https://github.com/Tortar/WrappedUnions.jl) which would have been a big breaking change for that library to be done appropriately, and I would like to change the link to that one instead of the previous one, because I think it has a much better interface for Julia in my opinion.